### PR TITLE
Refine summarization and env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,11 @@
 DISCORD_TOKEN=your_discord_token_here
 
 # Google Gemini API設定（Geminiを使用する場合）
-GEMINI_API_KEY=your_gemini_api_key_here
+# 奇数日と偶数日で切り替える2つのキーをカンマ区切りで指定できます
+# 例: GEMINI_API_KEYS=gemini_key1,gemini_key2
+GEMINI_API_KEYS=
+# 単一キーのみ使用する場合は下記を利用
+# GEMINI_API_KEY=your_gemini_api_key_here
 
 # LM Studio API設定（LM Studioを使用する場合）
 # ローカル実行: http://localhost:1234/v1

--- a/ai/ai_processor.py
+++ b/ai/ai_processor.py
@@ -9,6 +9,7 @@ AIプロセッサー
 
 import logging
 from typing import Dict, Any, Optional, List
+from utils.helpers import select_gemini_api_key
 
 from .lmstudio_api import LMStudioAPI
 from .gemini_api import GeminiAPI
@@ -62,6 +63,9 @@ class AIProcessor:
         """AIプロバイダに応じたAPIインスタンスを生成する"""
         if provider.startswith("gemini"):
             api_key = self.config.get("gemini_api_key", "")
+            keys = self.config.get("gemini_api_keys")
+            if keys:
+                api_key = select_gemini_api_key(keys)
             selected_model = model or "gemini-1.5-pro"
             logger.info(f"Google Gemini APIを使用します: {selected_model}")
             return GeminiAPI(api_key, model=selected_model)
@@ -155,7 +159,7 @@ class AIProcessor:
             summarizer = Summarizer(api)
 
         # 要約の生成
-        summary = await summarizer.summarize(content, max_length)
+        summary = await summarizer.summarize(content, max_length, summary_type or "normal")
 
         # 要約結果を記事に追加
         article["summary"] = summary

--- a/ai/gemini_api.py
+++ b/ai/gemini_api.py
@@ -27,7 +27,15 @@ class GeminiAPI:
             api_key: Google Gemini API Key（指定がない場合は環境変数から取得）
             model: 使用するモデル名
         """
-        self.api_key = api_key or os.environ.get("GEMINI_API_KEY", "")
+        if api_key:
+            self.api_key = api_key
+        else:
+            if os.environ.get("GEMINI_API_KEYS"):
+                from utils.helpers import select_gemini_api_key
+                keys = [k.strip() for k in os.environ.get("GEMINI_API_KEYS").split(',') if k.strip()]
+                self.api_key = select_gemini_api_key(keys)
+            else:
+                self.api_key = os.environ.get("GEMINI_API_KEY", "")
         if not self.api_key:
             logger.warning("Gemini API Keyが設定されていません")
 

--- a/ai/summarizer.py
+++ b/ai/summarizer.py
@@ -29,12 +29,12 @@ class Summarizer:
         """
         self.api = api
         self.system_instruction = system_instruction or (
-            "あなたはプロの翻訳者兼要約者です。与えられた文章の要点を抽出し、" 
-            "箇条書きで三つのポイントにまとめます。日本語で簡潔かつ正確に記述してください。"
+            "あなたはプロの翻訳者兼要約者です。与えられた文章の要点を抽出し、"
+            "箇条書きを使わず簡潔な文章でまとめます。日本語で分かりやすく記述してください。"
         )
         logger.info("要約機能を初期化しました")
     
-    async def summarize(self, text: str, max_length: int = 200) -> str:
+    async def summarize(self, text: str, max_length: int = 200, summary_type: str = "normal") -> str:
         """
         テキストを要約する
         
@@ -50,12 +50,26 @@ class Summarizer:
         
         try:
             # 要約および翻訳プロンプトの作成
-            prompt = (
-                "あなたはニュース編集者です。次の文章を日本語で三つの箇条書きに要約してください。"
-                "重要なポイントを抽出し、ですます調でまとめてください。"
-                f"必ず{max_length}文字以内で、要約以外の出力はしないでください。\n\n"
-                f"テキスト:\n{text}\n\n要約:"
-            )
+            if summary_type == "short":
+                prompt = (
+                    "あなたはニュース編集者です。以下の文章を日本語で簡潔に一文で要約してください。"
+                    f"{max_length}文字以内でまとめてください。\n\n"
+                    f"テキスト:\n{text}\n\n要約:"
+                )
+            elif summary_type == "long":
+                prompt = (
+                    "あなたはニュース編集者です。以下の文章を日本語で詳しく要約してください。"
+                    "箇条書きを使わず3〜5文程度の文章でまとめてください。"
+                    f"必ず{max_length}文字以内で記述してください。\n\n"
+                    f"テキスト:\n{text}\n\n要約:"
+                )
+            else:
+                prompt = (
+                    "あなたはニュース編集者です。以下の文章を日本語で分かりやすく要約してください。"
+                    "2〜3文以内の文章で、箇条書きを使わずにまとめてください。"
+                    f"{max_length}文字以内で書いてください。\n\n"
+                    f"テキスト:\n{text}\n\n要約:"
+                )
             
             # APIを使用して要約
             if isinstance(self.api, GeminiAPI):

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -140,3 +140,8 @@ class ConfigManager:
             self.config["gemini_api_key"] = os.environ.get("GEMINI_API_KEY")
             logger.info("環境変数からGemini APIキーを読み込みました")
 
+        if not self.config.get("gemini_api_keys") and os.environ.get("GEMINI_API_KEYS"):
+            keys = [k.strip() for k in os.environ.get("GEMINI_API_KEYS").split(',') if k.strip()]
+            self.config["gemini_api_keys"] = keys
+            logger.info("環境変数からGemini APIキーのリストを読み込みました")
+

--- a/config/default_config.py
+++ b/config/default_config.py
@@ -24,7 +24,8 @@ DEFAULT_CONFIG = {
     "ai_provider": "lmstudio",  # AIプロバイダ（lmstudio or gemini）
     "fallback_ai_provider": "gemini",  # 予備のAIプロバイダ
     "lmstudio_api_url": "http://localhost:1234/v1",  # LM Studio API URL
-    "gemini_api_key": "",  # Google Gemini API Key
+    "gemini_api_key": "",  # Google Gemini API Key (旧形式)
+    "gemini_api_keys": [],  # Gemini API Keyのリスト
     "ai_model": "lmstudio",  # 使用するAIモデル
                               # gemini-2.0-flash, gemini-2.5-flash-preview-05-20, lmstudio
     "summarize": True,     # 要約（翻訳を兼ねる）を有効にするか

--- a/docker_guide.md
+++ b/docker_guide.md
@@ -25,7 +25,12 @@ cp .env.example .env
 DISCORD_TOKEN=your_discord_token_here
 
 # Google Gemini API設定（Gemini APIを使用する場合）
-GEMINI_API_KEY=your_gemini_api_key_here
+# GEMINI_API_KEYS に gemini1 と gemini2 のキーをカンマ区切りで指定すると、
+# 奇数日と偶数日で自動的に切り替えます
+# 例: GEMINI_API_KEYS=gemini_key1,gemini_key2
+GEMINI_API_KEYS=
+# 単一キーのみ使用する場合は GEMINI_API_KEY を設定
+# GEMINI_API_KEY=your_gemini_api_key_here
 
 # LM Studio API設定（LM Studioを使用する場合）
 # LM Studio APIコンテナを起動する場合は、以下のURLを指定してください

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -172,7 +172,7 @@ from ai.ai_processor import AIProcessor
 # processor = AIProcessor(config)
 
 # 要約（自動翻訳を含む）
-# summary = await processor.summarize(text, max_length=200)
+# summary = await processor.summarize(text, max_length=200, summary_type="normal")
 
 # ジャンル分類
 # category = await processor.classify(text)
@@ -189,7 +189,7 @@ from ai.lmstudio_api import LMStudioAPI
 processor = LMStudioAPI(config)
 
 # 要約（自動翻訳を含む）
-summary = await processor.summarize(text, max_length=200)
+summary = await processor.summarize(text, max_length=200, summary_type="normal")
 
 # ジャンル分類
 category = await processor.classify(text)
@@ -207,7 +207,7 @@ from ai.gemini_api import GeminiAPI
 processor = GeminiAPI(api_key="YOUR_API_KEY", model="gemini-1.5-pro")
 
 # 要約（自動翻訳を含む）
-summary = await processor.summarize(text, max_length=200)
+summary = await processor.summarize(text, max_length=200, summary_type="normal")
 
 # ジャンル分類
 category = await processor.classify(text)
@@ -224,7 +224,7 @@ from ai.summarizer import Summarizer
 summarizer = Summarizer(ai_processor)
 
 # 要約
-summary = await summarizer.summarize(text, max_length=200)
+summary = await summarizer.summarize(text, max_length=200, summary_type="normal")
 ```
 
 ### Classifier

--- a/docs/installation_guide.md
+++ b/docs/installation_guide.md
@@ -110,7 +110,12 @@ docker-compose up -d
 DISCORD_TOKEN=your_discord_token_here
 
 # Google Gemini API設定（Gemini APIを使用する場合）
-GEMINI_API_KEY=your_gemini_api_key_here
+# GEMINI_API_KEYS に gemini1 と gemini2 のキーをカンマ区切りで設定すると、
+# ボットは奇数日と偶数日でキーを切り替えます
+# 例: GEMINI_API_KEYS=gemini_key1,gemini_key2
+GEMINI_API_KEYS=
+# 1つだけ指定する場合は GEMINI_API_KEY を使用
+# GEMINI_API_KEY=your_gemini_api_key_here
 
 # LM Studio API設定（LM Studioを使用する場合）
 # ローカル実行時は http://localhost:1234/v1

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -97,7 +97,7 @@ AIプロバイダを選択するには、`/rss_config`コマンドを使用し�
 
 ### 要約設定
 
-記事の要約を有効/無効にするには、`/rss_config`コマンドを使用して設定パネルを表示し、「要約」セクションで設定します。要約の文字数も設定できます。
+記事の要約を有効/無効にするには、`/rss_config`コマンドを使用して設定パネルを表示し、「要約」セクションで設定します。要約の文字数に加え、フィード追加時に`short`、`normal`、`long`の3種類から要約の長さを選択できます。要約は箇条書きではなく、短い文章で生成されます。
 
 ### ジャンル分類設定
 
@@ -153,7 +153,7 @@ Discord RSS Botは、記事情報を視覚的に表示するためにエンベ�
   "ai_provider": "gemini",
   "fallback_ai_provider": "gemini",
   "lmstudio_api_url": "http://localhost:1234/v1",
-  "gemini_api_key": "your_gemini_api_key"
+  "gemini_api_keys": ["your_gemini_api_key1", "your_gemini_api_key2"]
 }
 ```
 

--- a/tests/test_ai_processor.py
+++ b/tests/test_ai_processor.py
@@ -58,7 +58,7 @@ technical documentation describing the model's architecture and training methodo
         
         print("=== 要約テスト ===")
         summarizer = Summarizer(api)
-        summary = await summarizer.summarize(article["content"], 200)
+        summary = await summarizer.summarize(article["content"], 200, "normal")
         print(f"要約（200文字）: {summary}")
         print(f"文字数: {len(summary)}")
         print()

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -142,3 +142,17 @@ def get_channel_name_for_feed(feed_url: str, feed_title: str = None) -> str:
             return f"rss-feed-{hash_str}"
 
 
+
+
+# Gemini API key selection
+from typing import List
+
+
+def select_gemini_api_key(keys: List[str]) -> str:
+    """奇数日と偶数日で使用するGemini APIキーを切り替える"""
+    if not keys:
+        return ""
+    if len(keys) == 1:
+        return keys[0]
+    day = datetime.now().day
+    return keys[0] if day % 2 == 1 else keys[1]


### PR DESCRIPTION
## Summary
- 要約プロンプトを文章形式に変更
- .env.example で Gemini API キー例を `gemini_key1,gemini_key2` と明示
- ドキュメント更新 (Docker/インストール/ユーザーガイド)

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'apscheduler')*

------
https://chatgpt.com/codex/tasks/task_e_68455dffae8c83308e8777d13321f279