### PR TITLE
Fix thumbnail retrieval from media

### DIFF
--- a/discord_bot/message_builder.py
+++ b/discord_bot/message_builder.py
@@ -99,8 +99,16 @@ class MessageBuilder:
                     embed.add_field(name="公開日時", value=published, inline=True)
             
             # サムネイル画像の設定
-            if self.config.get("use_thumbnails", True) and article.get("image"):
-                embed.set_thumbnail(url=article.get("image"))
+            if self.config.get("use_thumbnails", True):
+                image_url = article.get("image")
+                if not image_url and article.get("media"):
+                    for media_item in article.get("media", []):
+                        if media_item.get("type", "").startswith("image") and media_item.get("url"):
+                            image_url = media_item.get("url")
+                            break
+
+                if image_url:
+                    embed.set_thumbnail(url=image_url)
             
             # フッター
             ai_info = []


### PR DESCRIPTION
## Summary
- fix `MessageBuilder` so it searches the article's media list when `image` is absent
- keep tests passing

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684588bd1dec8330b55025f3ca17dd7a