### PR TITLE
Fix embed thumbnail retrieval

### DIFF
--- a/discord_bot/message_builder.py
+++ b/discord_bot/message_builder.py
@@ -100,17 +100,21 @@ class MessageBuilder:
             
             # サムネイル画像の設定
             if self.config.get("use_thumbnails", True):
-                image_url = article.get("image")
+                image_url = None
+
+                # mediaキーから画像を探索
+                media_list = article.get("media")
+                if isinstance(media_list, list):
+                    for media_item in media_list:
+                        if isinstance(media_item, dict) and \
+                           media_item.get("type", "").startswith("image") and \
+                           media_item.get("url"):
+                            image_url = media_item.get("url")
+                            break
+
+                # 互換性のためimageキーもチェック
                 if not image_url:
-                    media_list = article.get("media")
-                    if isinstance(media_list, list):  # Ensure 'media' is a list
-                        for media_item in media_list:
-                            # Ensure media_item is a dictionary before calling .get()
-                            if isinstance(media_item, dict) and \
-                               media_item.get("type", "").startswith("image") and \
-                               media_item.get("url"):
-                                image_url = media_item.get("url")
-                                break
+                    image_url = article.get("image")
 
                 if image_url:
                     embed.set_thumbnail(url=image_url)

--- a/tests/test_message_builder.py
+++ b/tests/test_message_builder.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import unittest
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from discord_bot.message_builder import MessageBuilder
+
+class TestMessageBuilder(unittest.TestCase):
+    def setUp(self):
+        self.config = {"use_thumbnails": True, "embed_color": 3447003, "categories": []}
+        self.builder = MessageBuilder(self.config)
+
+    def test_media_thumbnail_used(self):
+        article = {
+            "title": "Test",
+            "link": "https://example.com",
+            "content": "content",
+            "media": [{"url": "https://example.com/image.jpg", "type": "image/jpeg"}]
+        }
+        embed = asyncio.get_event_loop().run_until_complete(
+            self.builder.build_article_embed(article)
+        )
+        self.assertEqual(embed.thumbnail.url, "https://example.com/image.jpg")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix message builder to load images from media list before fallback to `image`
- add regression test for thumbnail selection logic

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68459029c0808330af84eb15dad60cc2