### PR TITLE
Fix channel name bug in addrss command

### DIFF
--- a/discord_bot/bot_client.py
+++ b/discord_bot/bot_client.py
@@ -186,13 +186,19 @@ class DiscordBot:
             logger.error(f"メッセージ送信中にエラーが発生しました: {e}", exc_info=True)
             return False
     
-    async def create_feed_channel(self, guild_id: int, feed_info: Dict[str, Any]) -> Optional[str]:
+    async def create_feed_channel(
+        self,
+        guild_id: int,
+        feed_info: Dict[str, Any],
+        channel_name: Optional[str] = None,
+    ) -> Optional[str]:
         """
         フィード用のチャンネルを作成する
         
         Args:
             guild_id: サーバーID
             feed_info: フィード情報
+            channel_name: チャンネル名（オプション）
             
         Returns:
             作成されたチャンネルID、失敗した場合はNone
@@ -207,7 +213,8 @@ class DiscordBot:
             # チャンネル名の生成
             feed_title = feed_info.get("title", "Unknown Feed")
             feed_url = feed_info.get("url", "")
-            channel_name = get_channel_name_for_feed(feed_url, feed_title)
+            if not channel_name:
+                channel_name = get_channel_name_for_feed(feed_url, feed_title)
             
             # カテゴリの取得
             category_id = self.config.get("category_id")

--- a/discord_bot/commands.py
+++ b/discord_bot/commands.py
@@ -190,7 +190,8 @@ async def register_commands(bot: commands.Bot, config: Dict[str, Any]):
                     # チャンネルが存在しない場合は作成
                     channel_id = await feed_manager.discord_bot.create_feed_channel(
                         interaction.guild.id,
-                        feed_info
+                        feed_info,
+                        channel_name=channel_name,
                     )
                 else:
                     channel_id = str(channel.id)

--- a/discord_bot/ui_components.py
+++ b/discord_bot/ui_components.py
@@ -503,7 +503,8 @@ class AddFeedModal(ui.Modal, title="フィード追加"):
                     # チャンネルが存在しない場合は作成
                     channel_id = await self.feed_manager.discord_bot.create_feed_channel(
                         interaction.guild.id,
-                        feed_info
+                        feed_info,
+                        channel_name=channel_name,
                     )
                 else:
                     channel_id = str(channel.id)


### PR DESCRIPTION
## Summary
- ensure custom `channel_name` provided with `/addrss` is used when creating channels
- propagate channel name from commands and UI to the channel creation helper

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a2ce55c48330b7332417bbe31b2a