### PR TITLE
Fix missing asyncio import

### DIFF
--- a/ai/ai_processor.py
+++ b/ai/ai_processor.py
@@ -8,6 +8,7 @@ AIプロセッサー
 """
 
 import logging
+import asyncio
 from typing import Dict, Any, Optional, List
 from utils.helpers import select_gemini_api_key
 


### PR DESCRIPTION
## Summary
- import asyncio in AIProcessor to avoid missing name errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845b2dcc11c8330810f05e119a46b19