### PR TITLE
Update summary length handling

### DIFF
--- a/ai/summarizer.py
+++ b/ai/summarizer.py
@@ -61,19 +61,16 @@ class Summarizer:
                         "次の文章を日本語で2〜3文、100文字以内で要約してください。\n\n"
                         f"{text}\n\n要約:"
                     )
-                    max_length = min(max_length, 120)
                 elif summary_type == "long":
                     prompt = (
                         "次の文章を日本語で詳細に500文字以内で要約してください。読みやすいように適度に改行してください。\n\n"
                         f"{text}\n\n要約:"
                     )
-                    max_length = min(max_length, 500)
                 else:
                     prompt = (
                         "次の文章を日本語で200文字以内で要約してください。読みやすいように適度に改行してください。\n\n"
                         f"{text}\n\n要約:"
                     )
-                    max_length = min(max_length, 200)
             
             # APIを使用して要約
             if isinstance(self.api, GeminiAPI):


### PR DESCRIPTION
## Summary
- adjust summarizer so summary length isn't forcibly capped at 120/500/200 characters

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845c0a3c4c08330976c0891f0fc0d6f