### PR TITLE
Add feed/channel removal and Gemini API key UI

### DIFF
--- a/ai/gemini_api.py
+++ b/ai/gemini_api.py
@@ -30,30 +30,26 @@ class GeminiAPI:
             api_key: Google Gemini API Key（指定がない場合は環境変数から取得）
             model: 使用するモデル名
         """
-        if api_keys:
-            self.api_keys = [k for k in api_keys if k]
-        else:
-            self.api_keys = []
+        self.api_keys = [k for k in (api_keys or []) if k]
 
         if api_key:
-            self.api_keys = [api_key] + [k for k in self.api_keys if k != api_key]
+            if api_key not in self.api_keys:
+                self.api_keys.insert(0, api_key)
 
-        if not self.api_keys:
-            env_keys = []
-            if os.environ.get("GEMINI_API_1") or os.environ.get("GEMINI_API_2"):
-                if os.environ.get("GEMINI_API_1"):
-                    env_keys.append(os.environ.get("GEMINI_API_1"))
-                if os.environ.get("GEMINI_API_2"):
-                    env_keys.append(os.environ.get("GEMINI_API_2"))
-            elif os.environ.get("GEMINI_API_KEYS"):
-                env_keys = [k.strip() for k in os.environ.get("GEMINI_API_KEYS").split(',') if k.strip()]
+        env_keys = []
+        if os.environ.get("GEMINI_API_1") or os.environ.get("GEMINI_API_2"):
+            if os.environ.get("GEMINI_API_1"):
+                env_keys.append(os.environ.get("GEMINI_API_1"))
+            if os.environ.get("GEMINI_API_2"):
+                env_keys.append(os.environ.get("GEMINI_API_2"))
+        elif os.environ.get("GEMINI_API_KEYS"):
+            env_keys = [k.strip() for k in os.environ.get("GEMINI_API_KEYS").split(',') if k.strip()]
+        elif os.environ.get("GEMINI_API_KEY"):
+            env_keys.append(os.environ.get("GEMINI_API_KEY"))
 
-            if env_keys:
-                self.api_keys = env_keys
-            else:
-                env_key = os.environ.get("GEMINI_API_KEY")
-                if env_key:
-                    self.api_keys = [env_key]
+        for key in env_keys:
+            if key not in self.api_keys:
+                self.api_keys.append(key)
 
         if self.api_keys:
             from utils.helpers import select_gemini_api_key

--- a/discord_bot/commands.py
+++ b/discord_bot/commands.py
@@ -155,6 +155,7 @@ async def register_commands(bot: commands.Bot, config: Dict[str, Any]):
     @app_commands.describe(
         url="RSSフィードのURL",
         channel_name="チャンネル名（省略可）",
+        existing_channel="既存のチャンネル",
         summary_length="要約の長さ"
     )
     @app_commands.choices(summary_length=[
@@ -166,6 +167,7 @@ async def register_commands(bot: commands.Bot, config: Dict[str, Any]):
         interaction: discord.Interaction,
         url: str,
         channel_name: str = None,
+        existing_channel: discord.TextChannel = None,
         summary_length: str = "normal",
     ):
         """RSSフィードを追加するコマンド"""
@@ -190,7 +192,9 @@ async def register_commands(bot: commands.Bot, config: Dict[str, Any]):
                 return
             
             # チャンネルの作成または指定
-            if channel_name:
+            if existing_channel:
+                channel_id = str(existing_channel.id)
+            elif channel_name:
                 # 既存のチャンネルを検索
                 channel = discord.utils.get(interaction.guild.text_channels, name=channel_name)
                 if not channel:


### PR DESCRIPTION
## Summary
- allow selecting existing channel when adding RSS feed
- support removing feeds or channels via `/rss list_feeds`
- add Gemini API key add modal and prioritize config keys
- combine Gemini API keys from config and environment for fallback

## Testing
- `python3 run_tests.py` *(fails: ModuleNotFoundError for optional deps)*

------
https://chatgpt.com/codex/tasks/task_e_68482d82c9e483309885837702eaec29