### PR TITLE
Improve question answering via related article search

### DIFF
--- a/discord_bot/bot_client.py
+++ b/discord_bot/bot_client.py
@@ -111,7 +111,9 @@ class DiscordBot:
             if ref and ref.author.id == self.bot.user.id:
                 article = await self.feed_manager.article_store.get_full_article(str(ref.id))
                 if article:
-                    answer = await self.ai_processor.answer_question(article, message.content)
+                    keywords = await self.ai_processor._generate_search_keywords(article, message.content)
+                    related = await self.feed_manager.article_store.find_related_articles(keywords, str(ref.id))
+                    answer = await self.ai_processor.answer_question(article, related, message.content)
                     await message.reply(answer)
                     return
 

--- a/discord_bot/commands.py
+++ b/discord_bot/commands.py
@@ -107,7 +107,12 @@ async def register_commands(bot: commands.Bot, config: Dict[str, Any]):
             processed = await feed_manager.ai_processor.process_article(entry, feed)
             msg_id = await feed_manager.discord_bot.post_article(processed, channel_id)
             if msg_id:
-                await feed_manager.article_store.add_full_article(str(msg_id), channel_id, entry)
+                await feed_manager.article_store.add_full_article(
+                    str(msg_id),
+                    channel_id,
+                    entry,
+                    processed.get("keywords_en", ""),
+                )
             await interaction.followup.send("記事を投稿しました。", ephemeral=True)
         except Exception as e:
             logger.error(f"フィード確認中にエラーが発生しました: {e}", exc_info=True)

--- a/rss/feed_manager.py
+++ b/rss/feed_manager.py
@@ -57,7 +57,12 @@ class FeedManager:
                 processed = await self.ai_processor.process_article(article, feed)
                 message_id = await self.discord_bot.post_article(processed, channel_id)
                 if message_id:
-                    await self.article_store.add_full_article(str(message_id), channel_id, article)
+                    await self.article_store.add_full_article(
+                        str(message_id),
+                        channel_id,
+                        article,
+                        processed.get("keywords_en", ""),
+                    )
                 article_id = generate_article_id(article)
                 await self.article_store.add_processed_article(article_id, url, channel_id)
             except Exception as e:


### PR DESCRIPTION
## Summary
- store `keywords_en` in the articles DB table
- save keywords extracted by AI when storing an article
- search for related articles based on keywords
- extract keywords for searching and use them when answering
- include related articles when the bot answers a user question

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684c30c2dc048330878c491911328049