### PR TITLE
Handle model/key updates for AIProcessor

### DIFF
--- a/ai/ai_processor.py
+++ b/ai/ai_processor.py
@@ -53,9 +53,15 @@ class AIProcessor:
         self.qa_model = self.config.get("qa_model", self.ai_model)
 
         if self.api:
-            await self.api.close()
+            try:
+                await self.api.close()
+            except Exception as e:
+                logger.warning(f"Error closing main API client during reload: {e}")
         if self.qa_api:
-            await self.qa_api.close()
+            try:
+                await self.qa_api.close()
+            except Exception as e:
+                logger.warning(f"Error closing QA API client during reload: {e}")
 
         self.api = self._create_api(self.ai_model)
         self.qa_api = self._create_api(self.qa_model)

--- a/ai/ai_processor.py
+++ b/ai/ai_processor.py
@@ -47,6 +47,24 @@ class AIProcessor:
 
         logger.info("AIプロセッサーを初期化しました")
 
+    async def reload_from_config(self) -> None:
+        """設定の変更を反映してAPIクライアントを再初期化する"""
+        self.ai_model = self.config.get("ai_model", "gemini-2.0-flash")
+        self.qa_model = self.config.get("qa_model", self.ai_model)
+
+        if self.api:
+            await self.api.close()
+        if self.qa_api:
+            await self.qa_api.close()
+
+        self.api = self._create_api(self.ai_model)
+        self.qa_api = self._create_api(self.qa_model)
+
+        self.summarizer.api = self.api
+        self.classifier.api = self.api
+
+        logger.info("AIプロセッサーの設定を再読み込みしました")
+
     def _create_api(self, model: Optional[str] = None):
         """Google Gemini APIインスタンスを生成する"""
         api_key = self.config.get("gemini_api_key", "")

--- a/discord_bot/ui_components.py
+++ b/discord_bot/ui_components.py
@@ -191,7 +191,14 @@ class AIModelSelect(ui.Select):
         self.config_manager.update_config(self.config)
 
         # AIプロセッサーを再初期化
-        await self.feed_manager.ai_processor.reload_from_config()
+        try:
+            await self.feed_manager.ai_processor.reload_from_config()
+        except Exception as e:
+            logger.error(f"AIプロセッサーの再読み込みに失敗しました (model select): {e}", exc_info=True)
+            await interaction.response.send_message(
+                f"AIモデルを「{selected}」に設定しましたが、プロセッサーの再読み込み中にエラーが発生しました。詳細はログを確認してください。", ephemeral=True
+            )
+            return
 
         # 応答を送信
         await interaction.response.send_message(

--- a/discord_bot/ui_components.py
+++ b/discord_bot/ui_components.py
@@ -417,7 +417,14 @@ class GeminiAPIKeyModal(ui.Modal, title="Gemini APIキー追加"):
             keys.insert(0, key)
             self.config["gemini_api_keys"] = keys
             self.config_manager.update_config(self.config)
-            await self.feed_manager.ai_processor.reload_from_config()
+            try:
+                await self.feed_manager.ai_processor.reload_from_config()
+            except Exception as e:
+                logger.error(f"AIプロセッサーの再読み込みに失敗しました (API key add): {e}", exc_info=True)
+                await interaction.response.send_message(
+                    "Gemini APIキーを追加しましたが、AIプロセッサーの再読み込み中にエラーが発生しました。詳細はログを確認してください。", ephemeral=True
+                )
+                return
         await interaction.response.send_message(
             "Gemini APIキーを追加しました", ephemeral=True
         )

--- a/discord_bot/ui_components.py
+++ b/discord_bot/ui_components.py
@@ -191,8 +191,7 @@ class AIModelSelect(ui.Select):
         self.config_manager.update_config(self.config)
 
         # AIプロセッサーを再初期化
-        # AIプロセッサーの再設定が必要な場合はここで実施
-        await self.feed_manager.ai_processor.api.close()
+        await self.feed_manager.ai_processor.reload_from_config()
 
         # 応答を送信
         await interaction.response.send_message(
@@ -411,7 +410,7 @@ class GeminiAPIKeyModal(ui.Modal, title="Gemini APIキー追加"):
             keys.insert(0, key)
             self.config["gemini_api_keys"] = keys
             self.config_manager.update_config(self.config)
-            await self.feed_manager.ai_processor.api.close()
+            await self.feed_manager.ai_processor.reload_from_config()
         await interaction.response.send_message(
             "Gemini APIキーを追加しました", ephemeral=True
         )


### PR DESCRIPTION
## Summary
- reload AIProcessor when model or key changes
- use updated API clients in UI callbacks

## Testing
- `python3 run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_684c44cf1414833083443bbb9a8bdc86