### PR TITLE
Add search keywords and related article answer features

### DIFF
--- a/discord_bot/bot_client.py
+++ b/discord_bot/bot_client.py
@@ -109,9 +109,11 @@ class DiscordBot:
                 ref = None
 
             if ref and ref.author.id == self.bot.user.id:
-                article = await self.feed_manager.article_store.get_full_article(str(ref.id))
-                if article:
-                    answer = await self.ai_processor.answer_question(article, message.content)
+                original_article = await self.feed_manager.article_store.get_full_article(str(ref.id))
+                if original_article:
+                    keywords = await self.ai_processor._generate_search_keywords(original_article, message.content)
+                    related_articles = await self.feed_manager.article_store.find_related_articles(keywords, str(ref.id))
+                    answer = await self.ai_processor.answer_question(original_article, related_articles, message.content)
                     await message.reply(answer)
                     return
 

--- a/discord_bot/commands.py
+++ b/discord_bot/commands.py
@@ -107,7 +107,12 @@ async def register_commands(bot: commands.Bot, config: Dict[str, Any]):
             processed = await feed_manager.ai_processor.process_article(entry, feed)
             msg_id = await feed_manager.discord_bot.post_article(processed, channel_id)
             if msg_id:
-                await feed_manager.article_store.add_full_article(str(msg_id), channel_id, entry)
+                await feed_manager.article_store.add_full_article(
+                    str(msg_id),
+                    channel_id,
+                    entry,
+                    processed.get("keywords_en", ""),
+                )
             await interaction.followup.send("記事を投稿しました。", ephemeral=True)
         except Exception as e:
             logger.error(f"フィード確認中にエラーが発生しました: {e}", exc_info=True)

--- a/rss/feed_manager.py
+++ b/rss/feed_manager.py
@@ -57,7 +57,12 @@ class FeedManager:
                 processed = await self.ai_processor.process_article(article, feed)
                 message_id = await self.discord_bot.post_article(processed, channel_id)
                 if message_id:
-                    await self.article_store.add_full_article(str(message_id), channel_id, article)
+                    await self.article_store.add_full_article(
+                        str(message_id),
+                        channel_id,
+                        article,
+                        processed.get("keywords_en", ""),
+                    )
                 article_id = generate_article_id(article)
                 await self.article_store.add_processed_article(article_id, url, channel_id)
             except Exception as e:


### PR DESCRIPTION
## Summary
- DBスキーマに `keywords_en` カラムを追加して記事毎の検索用キーワードを保存
- 記事処理時にGemini APIを用いてキーワード抽出し保存
- 質問応答時に元記事と関連記事を参照し、回答生成に `gemini-2.5-flash` を使用
- 記事保存処理・コマンド処理を更新しキーワードをDBへ登録
- ボット返信時に検索キーワード生成と関連記事取得を行う
- Gemini API利用コードを新SDK `google-genai` に更新

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4f0a5c5c8330b1c2f0060735129a